### PR TITLE
feat: add default value to jsdoc for step cache

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -36,6 +36,7 @@ export type Step =
     cacheDir?: CacheDir;
     /**
      * Disable caching for this step, this will cause the step to run every time, it may cause subsequent steps to run as well.
+     * @default false
      */
     cache?: boolean;
     /**


### PR DESCRIPTION
It's just a super small change, but I noticed that's it not super clear that caching **is** enabled by default. I think this might make this clearer