### PR TITLE
Fix CI in forked repositories

### DIFF
--- a/crates/cli/src/git.rs
+++ b/crates/cli/src/git.rs
@@ -115,7 +115,8 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_github_repo() {
+    #[ignore = "passing only in the upstream repository: cicadahq/cicada"]
+    async fn test_remote_is_github_cicadahq_cicada() {
         let gh = github_repo().await.unwrap().unwrap();
         assert_eq!(gh.owner, "cicadahq");
         assert_eq!(gh.repo, "cicada");

--- a/crates/cli/src/job.rs
+++ b/crates/cli/src/job.rs
@@ -171,7 +171,7 @@ pub struct Job {
 }
 
 impl Job {
-    /// This comverts the job into a dockerfile definition, the plan is to convert this into
+    /// This converts the job into a dockerfile definition, the plan is to convert this into
     /// a direct llb definition in the future
     pub fn to_dockerfile(
         &self,


### PR DESCRIPTION
The Git test fails for freshly forked repositories.
This PR ignores the test and renames it to reflect its purpose.