### PR TITLE
Add default properites to telemetry

### DIFF
--- a/crates/cli/src/telemetry/segment.rs
+++ b/crates/cli/src/telemetry/segment.rs
@@ -51,7 +51,11 @@ impl TrackEvent {
             ),
         };
 
-        // insert the default properties (os, architecture, environment, cli_version)
+        // Insert the default properties (os, architecture, environment, cli_version)
+        //
+        // Want to make sure the telemetry is useful but not too identifying basically
+        // just identify which binary build is being used and nothing about the user's
+        // env or machine besides that
         properties.insert("os".to_owned(), std::env::consts::OS.into());
         properties.insert("architecture".to_owned(), std::env::consts::ARCH.into());
 

--- a/crates/cli/src/telemetry/sentry.rs
+++ b/crates/cli/src/telemetry/sentry.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sentry::ClientInitGuard;
 
 use super::{sentry_enabled, SENTRY_AUTH_TOKEN};
@@ -11,6 +13,11 @@ pub(crate) fn sentry_init() -> Option<ClientInitGuard> {
                 token,
                 sentry::ClientOptions {
                     release: sentry::release_name!(),
+                    before_send: Some(Arc::new(|mut event| {
+                        // This is too identifying
+                        event.server_name = None;
+                        Some(event)
+                    })),
                     ..Default::default()
                 },
             ))


### PR DESCRIPTION
Want to make sure the telemetry is useful but not too identifying, I think this as the set of default properties make sense. They basically just identify which binary build is being used and nothing about the user's env or machine besides that.