### PR TITLE
feat: Make managed-bins feature a default

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 authors.workspace = true
 
 [features]
-default = []
+default = ["managed-bins"]
 # downloads a managed version of deno/buildctl if a valid version is not found on the path
 managed-bins = ["dep:zip", "dep:tar", "dep:flate2"]
 # enables segment + sentry telemetry


### PR DESCRIPTION
Working and production builds of the Cicada CLI seem unable to see installations of Buildkit (buildctl) on WSL Ubuntu 22.04.2 LTS.

This potentially affects other distros as well.

Per @grant0417, running with the optional managed-bins feature solves the issue.

Though the feature requires a networking dependency that isn't ideal, @grant0417 recommends it be the default for now.